### PR TITLE
keep same order in perfdata

### DIFF
--- a/check_gpu_sensor
+++ b/check_gpu_sensor
@@ -297,7 +297,7 @@ sub get_status_string{
 	}
 	#Collect performance values followed by thresholds
 	if($level eq "Performance"){
-		foreach my $k (keys %$curr_sensors){
+		foreach my $k (sort {lc $a cmp lc $b} keys %$curr_sensors){
 			$status_string .= $k."=".$curr_sensors->{$k};
 			#print warn and crit thresholds
 			if(exists $PERF_THRESHOLDS{$k}){


### PR DESCRIPTION
Keep same order in perfdata.
This will prevent random ordering of graphs and fix graphs selection/basket in some graphing solutions like pnp.